### PR TITLE
fix IllegalStateException when orientation changes in viewpager

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/viewmodelviewpagershowexample/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/example/viewmodelviewpagershowexample/fragments/HomeFragment.kt
@@ -46,7 +46,7 @@ class HomeFragment():Fragment()
     private fun initViewPager2()
     {
         viewPager2 = rootView.findViewById(R.id.viewpager2)
-        adapter = ViewPager2Adapter(parentFragmentManager,lifecycle)
+        adapter = ViewPager2Adapter(childFragmentManager,lifecycle)
         viewPager2.adapter = adapter
 
         // TabLayout:


### PR DESCRIPTION
When using ViewPager in a Fragment, we should use the childFragmentManager to avoid the Exception:

> IllegalStateException: FragmentManager is already executing transactions

